### PR TITLE
fix disabling swipes mid-swipe

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -147,6 +147,7 @@ class Swiper extends Component {
   }
 
   onPanResponderMove = (event, gestureState) => {
+    if (!this.props.horizontalSwipe && !this.props.verticalSwipe) return
     this.props.onSwiping(this._animatedValueX, this._animatedValueY)
 
     let { overlayOpacityHorizontalThreshold, overlayOpacityVerticalThreshold } = this.props
@@ -201,6 +202,7 @@ class Swiper extends Component {
   }
 
   onPanResponderGrant = (event, gestureState) => {
+    if (!this.props.horizontalSwipe && !this.props.verticalSwipe) return
     this.props.dragStart && this.props.dragStart()
     if (!this.state.panResponderLocked) {
       this.state.pan.setOffset({
@@ -216,6 +218,7 @@ class Swiper extends Component {
   }
 
   validPanResponderRelease = () => {
+    if (!this.props.horizontalSwipe && !this.props.verticalSwipe) return true
     const {
       disableBottomSwipe,
       disableLeftSwipe,


### PR DESCRIPTION
Found this bug while using a Slider inside the deck swiper. As I started to slide, I would also swipe. Solution was to pass up disable swipe event when slider started, but I found that this caused the swiper to freak out and stutter and eventually break. This fixes it