### PR TITLE
replaced deprecated method for removing .addEventListener subscription

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -84,7 +84,7 @@ class Swiper extends Component {
     this._mounted = false
     this.state.pan.x.removeAllListeners()
     this.state.pan.y.removeAllListeners()
-    Dimensions.removeEventListener('change', this.onDimensionsChange)
+    this.dimensionsChangeSubscription.remove()
   }
 
   getCardStyle = () => {
@@ -110,7 +110,7 @@ class Swiper extends Component {
 
   initializeCardStyle = () => {
     // this.forceUpdate()
-    Dimensions.addEventListener('change', this.onDimensionsChange)
+    this.dimensionsChangeSubscription = Dimensions.addEventListener('change', this.onDimensionsChange)
   }
 
   initializePanResponder = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-deck-swiper",
-    "version": "2.0.7",
+    "version": "2.0.8",
     "description": "Awesome tinder like card swiper for react-native. Highly Customizable!",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
This error was appearing while replacing a screen, which contained Swiper component. 

The fix removes depreciation errors for ios and android.