### PR TITLE
Fix RN peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     },
     "peerDependencies": {
         "react": "^16.0.0-beta.5 || ^17.0.0 || ^18.0.0",
-        "react-native": "^0.49.1"
+        "react-native": ">=0.49.1"
     },
     "devDependencies": {
         "babel-eslint": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-deck-swiper",
-    "version": "2.0.12",
+    "version": "2.0.13",
     "description": "Awesome tinder like card swiper for react-native. Highly Customizable!",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Using a ^ on the version only allows updates to everything below the first non-zero number. So this only lets you use the package with react-native 0.49.x. Changing to >= lets you use it with any version. I assume that's why there are 449 forks because it appears to still work with latest react-native versions.