### PR TITLE
Added check for when card is swiped via ref function

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -376,7 +376,8 @@ class Swiper extends Component {
       this.props.onSwipedLeft,
       -this.props.horizontalThreshold,
       0,
-      mustDecrementCardIndex
+      mustDecrementCardIndex,
+      true
     )
   }
 
@@ -385,7 +386,8 @@ class Swiper extends Component {
       this.props.onSwipedRight,
       this.props.horizontalThreshold,
       0,
-      mustDecrementCardIndex
+      mustDecrementCardIndex,
+      true
     )
   }
 
@@ -394,7 +396,8 @@ class Swiper extends Component {
       this.props.onSwipedTop,
       0,
       -this.props.verticalThreshold,
-      mustDecrementCardIndex
+      mustDecrementCardIndex,
+      true
     )
   }
 
@@ -403,7 +406,8 @@ class Swiper extends Component {
       this.props.onSwipedBottom,
       0,
       this.props.verticalThreshold,
-      mustDecrementCardIndex
+      mustDecrementCardIndex,
+      true
     )
   }
 
@@ -411,7 +415,8 @@ class Swiper extends Component {
     onSwiped,
     x = this._animatedValueX,
     y = this._animatedValueY,
-    mustDecrementCardIndex = false
+    mustDecrementCardIndex = false,
+    isViaRef = false
   ) => {
     this.setState({ panResponderLocked: true })
     this.animateStack()
@@ -434,7 +439,7 @@ class Swiper extends Component {
         if (mustDecrementCardIndex) {
           this.decrementCardIndex(onSwiped)
         } else {
-          this.incrementCardIndex(onSwiped)
+          this.incrementCardIndex(onSwiped, isViaRef)
         }
       })
     })
@@ -501,13 +506,13 @@ class Swiper extends Component {
     }
   }
 
-  incrementCardIndex = onSwiped => {
+  incrementCardIndex = (onSwiped, isViaRef = false) => {
     const { firstCardIndex } = this.state
     const { infinite } = this.props
     let newCardIndex = firstCardIndex + 1
     let swipedAllCards = false
 
-    this.onSwipedCallbacks(onSwiped)
+    this.onSwipedCallbacks(onSwiped, isViaRef)
 
     const allSwipedCheck = () => newCardIndex === this.props.cards.length
 
@@ -553,12 +558,12 @@ class Swiper extends Component {
     return stackPositionsAndScales
   }
 
-  onSwipedCallbacks = (swipeDirectionCallback) => {
+  onSwipedCallbacks = (swipeDirectionCallback, isViaRef = false) => {
     const previousCardIndex = this.state.firstCardIndex
     this.props.onSwiped(previousCardIndex, this.props.cards[previousCardIndex])
     this.setState(this.rebuildStackValues)
     if (swipeDirectionCallback) {
-      swipeDirectionCallback(previousCardIndex, this.props.cards[previousCardIndex])
+      swipeDirectionCallback(previousCardIndex, this.props.cards[previousCardIndex], isViaRef)
     }
   }
 


### PR DESCRIPTION
### **Motivation:** 

We came across a use case in our project where we had to track whether the card was swiped by swiping or via a button that called the respective ref function that would swipe the card by itself. I've attached a video to show this action happening.

In the current implementation there was no way of knowing whether the card was swiped by the user themself or via the ref function, after the action takes place and we get a response from the back end. The basic flow is:
**Swipe(button or gesture) => api call sent to back end => response received from back end => analytics query sent which includes an id returned in the response from the back end**.

For that reason i added a third return value (**isViaRef**) to all swipe functions which returns **true** when any of the ref functions are called and **false** otherwise.

### **Video demonstration:**

https://github.com/webraptor/react-native-deck-swiper/assets/63896531/c86a5740-94e2-469e-8b9a-ece508fb5878

