### PR TITLE
Fix props type definition for React 18

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ declare module 'react-native-deck-swiper' {
     zoomFriction?: number;
   }
 
-  export default class Swiper<T> extends React.Component<SwiperProps<T>> {
+  export default class Swiper<T> extends React.Component<SwiperProps<T> & { children?: React.ReactNode | undefined }> {
     swipeLeft: (mustDecrementCardIndex?: boolean) => void;
     swipeRight: (mustDecrementCardIndex?: boolean) => void;
     swipeTop: (mustDecrementCardIndex?: boolean) => void;


### PR DESCRIPTION
This PR fixes an issue related to using this component in a project with React 18 where the `children` prop is not included by default by the `Component` class, causing the following error:

```tsx
Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Swiper> & Readonly<{}>'
```